### PR TITLE
.gitconfig: ask twice before sending emails

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -28,5 +28,7 @@
    smtpserverport = 587
    suppresscc = self
    chainreplyto = false
+   confirm = always
+   annotate = true
 [credential]
 	helper = /usr/share/doc/git/contrib/credential/libsecret/git-credential-libsecret


### PR DESCRIPTION
This will ensure an editor window pops up with the patches for a final review
and the user will be asked to confirm email headers before sending out.